### PR TITLE
Fix sentiment output

### DIFF
--- a/webapp/app_folder/routes.py
+++ b/webapp/app_folder/routes.py
@@ -20,10 +20,26 @@ def journalentry():
     form = JournalForm()
     if form.validate_on_submit():
         text = form.text.data
-        sentiment = lang_processor.sample_analyze_sentiment(text).document_sentiment.score
+        sentiment_analysis = lang_processor.sample_analyze_sentiment(text).document_sentiment
+        score = sentiment_analysis.score
+        magnitude = sentiment_analysis.magnitude
+        
+        # Use both score and magnitude to determine sentiment
+        if magnitude >= 0.5:  # If the magnitude is high, it's a strong sentiment
+            if score > 0:
+                sentiment = 'positive'  # Positive sentiment
+            elif score < 0:
+                sentiment = 'negative'  # Negative sentiment
+            else:
+                sentiment = 'neutral'  # Neutral sentiment
+        else:
+            sentiment = 'neutral'  # Low magnitude means the sentiment is weak or neutral
+
+        # Create a new post with sentiment information
         post = Post(sentiment=sentiment, user_id=current_user.id)
         db.session.add(post)
         db.session.commit()
+
         return redirect(url_for('analytics'))
     return render_template('journal-entry.html', title='Entry', form=form)
 


### PR DESCRIPTION
**Overview:**
This pull request enhances the sentiment analysis logic by using both the sentiment score and magnitude from the Google Cloud Natural Language API 🌐 to determine the overall sentiment of the text. Instead of relying solely on the score, which only reflects the direction (positive or negative), the magnitude is now used to assess the strength of the sentiment 💪. This allows for a more nuanced and accurate interpretation of the sentiment.

_Key Changes:_
_Sentiment Calculation 📊:_
- Previously, only the score was used to judge sentiment. The magnitude was ignored.
Now, both the score (which indicates whether the sentiment is positive or negative) and the magnitude (which shows how strong that sentiment is) are used together to determine the overall sentiment.

_Sentiment Categorization 💭:_
High Magnitude (≥ 0.5):
If the magnitude is strong, the sentiment is categorized based on the score:
Positive if the score is greater than 0.
Negative if the score is less than 0.
Neutral if the score is exactly 0, but still with a strong intensity.
Low Magnitude (< 0.5):
If the magnitude is weak, the sentiment is classified as neutral, regardless of the score.
Post Sentiment Recording 📝:

The final sentiment (based on both score and magnitude) is saved to the Post object in the database. This ensures that sentiment is more accurately recorded based on both emotional direction and strength.
Why These Changes Were Made:
More Accurate Sentiment Judgment ⚖️: Relying only on the score doesn't give a full picture of the sentiment. Some texts may have a weak positive or negative sentiment (low magnitude) but could still show a direction. By including magnitude, we can capture the strength of the sentiment as well.

Improved User Experience 😊: With a clearer understanding of sentiment strength, the application can provide more meaningful insights, whether the sentiment is strongly negative, weakly positive, or neutral.
